### PR TITLE
feat: add reusable animation system and animate homepage sections

### DIFF
--- a/app/api/upload/media/route.ts
+++ b/app/api/upload/media/route.ts
@@ -1,36 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { v2 as cloudinary } from "cloudinary";
+import { ensureCloudinaryConfigured } from "@/lib/cloudinary";
 
 export const maxDuration = 60; // 60 seconds for video/audio uploads
-
-// Configure Cloudinary lazily (on first request) so `next build` can evaluate
-// this route without credentials present.
-let configured = false;
-function ensureCloudinaryConfigured(): void {
-  if (configured) return;
-
-  if (process.env.CLOUDINARY_URL) {
-    cloudinary.config();
-  } else {
-    const cloudName = process.env.CLOUDINARY_CLOUD_NAME;
-    const apiKey = process.env.CLOUDINARY_API_KEY;
-    const apiSecret = process.env.CLOUDINARY_API_SECRET;
-
-    if (!cloudName || !apiKey || !apiSecret) {
-      throw new Error(
-        "Missing Cloudinary configuration. Please set CLOUDINARY_URL or provide individual credentials."
-      );
-    }
-
-    cloudinary.config({
-      cloud_name: cloudName,
-      api_key: apiKey,
-      api_secret: apiSecret,
-    });
-  }
-
-  configured = true;
-}
 
 export async function POST(request: NextRequest) {
   try {

--- a/components/homePage/sections/Birthdays.tsx
+++ b/components/homePage/sections/Birthdays.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/components/ui/popover";
 import { FieldError, FieldGroup } from "@/components/ui/field";
 import { AnimatedButton } from "@/components/ui/animated-button";
+import { Reveal, Stagger, StaggerItem } from "@/components/motion";
 import type { Birthday } from "@/lib/types/birthdays";
 import { formatOrdinal } from "@/lib/utils";
 import { MONTHS, SAMPLE_BIRTHDAYS } from "@/lib/constants";
@@ -289,7 +290,9 @@ export default function MonthlyBirthdays({
       )}
 
       <div className="container">
-        <div className="text-center mb-12">
+        {/* Opacity-only reveal: a transform here would offset the rough-notation
+            Highlighter stroke, which measures the heading's position to draw. */}
+        <Reveal variant="fade" className="text-center mb-12">
           <div className="flex items-center justify-center text-sm text-muted-foreground uppercase tracking-[0.4em] mb-3 font-light gap-4">
             <Separator className="shrink sm:w-40!" />
             <p>Birthdays</p>
@@ -313,17 +316,21 @@ export default function MonthlyBirthdays({
             We celebrate all members born in {currentMonth}. God bless and keep
             you in this new year!
           </p>
-        </div>
+        </Reveal>
 
-        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
-          {initialBirthdays.length > 0
-            ? initialBirthdays.map((birthday) => (
-                <BirthdayCard key={birthday.id} birthday={birthday} />
-              ))
-            : SAMPLE_BIRTHDAYS.map((birthday) => (
-                <BirthdayCard key={birthday.id} birthday={birthday} />
-              ))}
-        </div>
+        <Stagger
+          stagger={0.07}
+          className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4"
+        >
+          {(initialBirthdays.length > 0
+            ? initialBirthdays
+            : SAMPLE_BIRTHDAYS
+          ).map((birthday) => (
+            <StaggerItem key={birthday.id}>
+              <BirthdayCard birthday={birthday} />
+            </StaggerItem>
+          ))}
+        </Stagger>
 
         {/* CTA */}
         <CtaContainer

--- a/components/homePage/sections/ChurchLocation.tsx
+++ b/components/homePage/sections/ChurchLocation.tsx
@@ -1,5 +1,6 @@
 import ChurchLocationMap from "../ChurchLocationMap";
 import ChurchLocationInfo from "../ChurchLocationInfo";
+import { Reveal } from "@/components/motion";
 import { CHURCH_INFO } from "@/lib/constants";
 
 export default function ChurchLocation() {
@@ -8,23 +9,23 @@ export default function ChurchLocation() {
   return (
     <section className="py-20 bg-gray-50 dark:bg-gray-900">
       <div className="container">
-        <div className="text-center mb-12">
+        <Reveal className="text-center mb-12">
           <h2 className="text-3xl md:text-4xl font-semibold mb-4">
             Find Our <span className="text-accent">Location</span>
           </h2>
           <p className="text-muted-foreground max-w-2xl mx-auto">
             {CHURCH_LOCATION.description}
           </p>
-        </div>
+        </Reveal>
 
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-          <div className="lg:col-span-2">
+          <Reveal variant="slide-right" className="lg:col-span-2">
             <ChurchLocationMap />
-          </div>
+          </Reveal>
 
-          <div className="space-y-6">
+          <Reveal variant="slide-left" className="space-y-6">
             <ChurchLocationInfo />
-          </div>
+          </Reveal>
         </div>
       </div>
     </section>

--- a/components/homePage/sections/ChurchServices.tsx
+++ b/components/homePage/sections/ChurchServices.tsx
@@ -11,23 +11,26 @@ import {
 } from "@/components/ui/card";
 import { BorderBeam } from "@/components/ui/border-beam";
 import { Badge } from "@/components/ui/badge";
+import { Reveal, Stagger, StaggerItem } from "@/components/motion";
 import { SERVICES } from "@/lib/constants";
 
 export default function ChurchServices() {
   return (
     <section className="small-container">
-      <SectionHeader
-        title="Church Services"
-        subtitle="Services"
-        description="Join us for worship, prayer, and fellowship throughout the week."
-      />
+      <Reveal>
+        <SectionHeader
+          title="Church Services"
+          subtitle="Services"
+          description="Join us for worship, prayer, and fellowship throughout the week."
+        />
+      </Reveal>
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8 auto-rows-fr">
+      <Stagger className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8 auto-rows-fr">
         {SERVICES.map((service) => {
           return (
+            <StaggerItem key={service.id} className="h-full">
             <Card
-              key={service.id}
-              className="group py-6 backdrop-blur-sm border-0 hover:shadow-primary/20 hover:-translate-y-1 transition-all duration-300"
+              className="group h-full py-6 backdrop-blur-sm border-0 hover:shadow-primary/20 hover:-translate-y-1 transition-all duration-300"
             >
               <BorderBeam
                 size={200}
@@ -59,9 +62,10 @@ export default function ChurchServices() {
                 </Badge>
               </CardFooter>
             </Card>
+            </StaggerItem>
           );
         })}
-      </div>
+      </Stagger>
     </section>
   );
 }

--- a/components/homePage/sections/Donation.tsx
+++ b/components/homePage/sections/Donation.tsx
@@ -1,5 +1,6 @@
 import { WordRotate } from "@/components/ui/word-rotate";
 import { AnimatedButton } from "@/components/ui/animated-button";
+import { Reveal } from "@/components/motion";
 import { DONATIONS } from "@/lib/constants";
 
 export default function Donation() {
@@ -17,7 +18,10 @@ export default function Donation() {
       <div className="absolute inset-0 bg-black/60 backdrop-blur-sm"></div>
 
       <div className="relative z-10 max-w-4xl mx-auto px-4 py-16 text-center text-white">
-        <div className="bg-white/10 backdrop-blur-md rounded-2xl p-8 md:p-12 border border-white/20 shadow-2xl">
+        <Reveal
+          variant="scale"
+          className="bg-white/10 backdrop-blur-md rounded-2xl p-8 md:p-12 border border-white/20 shadow-2xl"
+        >
           <h2 className="font-outfit">
             <span className="text-2xl">Give towards the </span>
             <WordRotate
@@ -50,7 +54,7 @@ export default function Donation() {
               text="Learn More"
             />
           </div>
-        </div>
+        </Reveal>
       </div>
 
       {/* Decorative elements */}

--- a/components/homePage/sections/FeaturedSermons.tsx
+++ b/components/homePage/sections/FeaturedSermons.tsx
@@ -1,21 +1,24 @@
 import Image from "next/image";
 import SermonBtn from "../SermonBtn";
 import SectionHeader from "@/components/SectionHeader";
+import { Reveal, Stagger, StaggerItem } from "@/components/motion";
 import { FEATURED_SERMONS } from "@/lib/constants";
 
 export default function FeaturedSermons() {
   return (
     <section>
       <div className="small-container">
-        <SectionHeader
-          title="Church Sermons"
-          subtitle="Sermons"
-          description="Watch and listen to powerful teachings from our pastors."
-        />
+        <Reveal>
+          <SectionHeader
+            title="Church Sermons"
+            subtitle="Sermons"
+            description="Watch and listen to powerful teachings from our pastors."
+          />
+        </Reveal>
 
-        <div className="flex flex-wrap justify-center gap-8">
+        <Stagger className="flex flex-wrap justify-center gap-8">
           {FEATURED_SERMONS.map((sermon, index) => (
-            <div
+            <StaggerItem
               key={sermon.id}
               className="group relative overflow-hidden text-center flex flex-col basis-full sm:basis-[calc(50%-theme(space.8)/2)] lg:basis-[calc(33.333%-theme(space.8)/1.5)] max-w-[420px] rounded"
             >
@@ -44,7 +47,7 @@ export default function FeaturedSermons() {
                   <p className="text-xs uppercase tracking-[0.2em]">
                     BY PASTOR:
                   </p>
-                  <p className="text-2xl italic -tracking-tight font-medium my-1">
+                  <p className="text-2xl italic tracking-wide font-medium my-1">
                     {sermon.pastor}
                   </p>
                 </div>
@@ -52,9 +55,9 @@ export default function FeaturedSermons() {
                   {sermon.date}
                 </p>
               </div>
-            </div>
+            </StaggerItem>
           ))}
-        </div>
+        </Stagger>
       </div>
     </section>
   );

--- a/components/homePage/sections/Features.tsx
+++ b/components/homePage/sections/Features.tsx
@@ -1,6 +1,7 @@
 import { IconComponent } from "@/components/IconComponent";
 import { AnimatedButton } from "@/components/ui/animated-button";
 import { Separator } from "@/components/ui/separator";
+import { Stagger, StaggerItem } from "@/components/motion";
 import { FEATURES, CHURCH_INFO } from "@/lib/constants";
 
 export default function Features() {
@@ -9,9 +10,9 @@ export default function Features() {
   return (
     <section className="bg-card">
       <div className="relative small-container py-14 pb-16 md:pb-20">
-        <div className="grid min-[480px]:grid-cols-2 sm:grid-cols-3 lg:grid-cols-9 gap-8 relative">
+        <Stagger className="grid min-[480px]:grid-cols-2 sm:grid-cols-3 lg:grid-cols-9 gap-8 relative">
           {FEATURES.map((feature, index) => (
-            <div
+            <StaggerItem
               key={index}
               className="group lg:col-span-2 flex flex-col h-full"
             >
@@ -29,10 +30,10 @@ export default function Features() {
               <blockquote className="border-l-2 pl-2 text-sm italic mt-auto">
                 {feature.bible}
               </blockquote>
-            </div>
+            </StaggerItem>
           ))}
 
-          <div className="text-center bg-primary text-primary-foreground lg:px-8 p-4 lg:-mt-30 lg:pt-20 sm:py-10 sm:col-span-3 flex flex-col items-center justify-center gap-4 group">
+          <StaggerItem className="text-center bg-primary text-primary-foreground lg:px-8 p-4 lg:-mt-30 lg:pt-20 sm:py-10 sm:col-span-3 flex flex-col items-center justify-center gap-4 group">
             <h4 className="text-2xl">THE MANDATE</h4>
 
             <blockquote className="sm:border-l-2 border-secondary/30 sm:pl-2 text-lg mt-6 italic leading-7 transition-all duration-300 group-hover:border-l-0 group-hover:pl-0">
@@ -46,8 +47,8 @@ export default function Features() {
               text="Partake this mission"
               href="https://faithtabernacle.org.ng/mandate/"
             />
-          </div>
-        </div>
+          </StaggerItem>
+        </Stagger>
       </div>
     </section>
   );

--- a/components/homePage/sections/Gallery.tsx
+++ b/components/homePage/sections/Gallery.tsx
@@ -1,4 +1,5 @@
 import SectionHeader from "@/components/SectionHeader";
+import { Reveal } from "@/components/motion";
 import { InfiniteSlider } from "@/components/ui/infinite-slider";
 import { ProgressiveBlur } from "@/components/ui/progressive-blur";
 import { getGalleryImagesServer } from "@/lib/data/gallery.server";
@@ -36,13 +37,13 @@ export default async function Gallery() {
   return (
     <section className="py-20">
       <div className="max-w-500 w-full mx-auto">
-        <div className="px-4">
+        <Reveal className="px-4">
           <SectionHeader
             title="Photo Collections"
             subtitle="Gallery"
             description="Pictures from documented events, special occasions and during service"
           />
-        </div>
+        </Reveal>
 
         <div className="relative">
           {count === 0 ? (

--- a/components/homePage/sections/HeroCarousel.tsx
+++ b/components/homePage/sections/HeroCarousel.tsx
@@ -3,11 +3,13 @@ import { HeroCarouselWrapper } from "../HeroCarouselWrapper";
 import { CarouselItem } from "@/components/ui/carousel";
 import { Separator } from "@/components/ui/separator";
 import { AnimatedButton } from "@/components/ui/animated-button";
+import { Reveal } from "@/components/motion";
 import { SLIDES } from "@/lib/constants";
 
 export default function HeroCarousel() {
   return (
     <main className="relative overflow-hidden">
+      <Reveal variant="fade" className="h-full">
       <HeroCarouselWrapper>
         {SLIDES.map((slide, index) => (
           <CarouselItem key={index} className="h-full p-0">
@@ -79,6 +81,7 @@ export default function HeroCarousel() {
           </CarouselItem>
         ))}
       </HeroCarouselWrapper>
+      </Reveal>
     </main>
   );
 }

--- a/components/homePage/sections/Testimonies.tsx
+++ b/components/homePage/sections/Testimonies.tsx
@@ -17,6 +17,7 @@ import {
 import { BorderBeam } from "@/components/ui/border-beam";
 import { VideoDialog } from "@/components/ui/video-dialog";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Reveal } from "@/components/motion";
 import AutoScroll from "embla-carousel-auto-scroll";
 import type { Testimony } from "@/lib/types/testimonies";
 import { cn, getEmbedUrl, getAvatarInitials } from "@/lib/utils";
@@ -36,13 +37,13 @@ export default function TestimoniesSection({
     return (
       <section className="py-20 bg-linear-to-br from-foreground/5 to-background">
         <div className="max-w-500 w-full mx-auto">
-          <div className="px-4">
+          <Reveal className="px-4">
             <SectionHeader
               title="Wonders of God in the Community"
               subtitle="Testimonies"
               description="Hear from our church family about how God has worked in their lives"
             />
-          </div>
+          </Reveal>
           <div className="px-4 mt-8">
             <TestimoniesEmpty />
           </div>
@@ -54,13 +55,13 @@ export default function TestimoniesSection({
   return (
     <section className="py-20 bg-linear-to-br from-foreground/5 to-background">
       <div className="max-w-500 w-full mx-auto">
-        <div className="px-4">
+        <Reveal className="px-4">
           <SectionHeader
             title="Wonders of God in the Community"
             subtitle="Testimonies"
             description="Hear from our church family about how God has worked in their lives"
           />
-        </div>
+        </Reveal>
 
         <div>
           <Carousel

--- a/components/homePage/sections/UpcomingEvents.tsx
+++ b/components/homePage/sections/UpcomingEvents.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image";
 import SectionHeader from "@/components/SectionHeader";
 import CaretButton from "@/components/ui/caret-button";
+import { Reveal, Stagger, StaggerItem } from "@/components/motion";
 import { formatEventDateTime } from "@/lib/utils";
 import { UPCOMING_EVENTS } from "@/lib/constants";
 
@@ -8,19 +9,21 @@ export default function UpcomingEvents() {
   return (
     <section className="py-20 bg-cover bg-center relative bg-[url(/images/bg-covenant_exchange.jpg)]">
       <div className="max-w-500 w-full mx-auto px-4">
-        <SectionHeader
-          title="Upcoming Events"
-          subtitle="Events"
-          description="Stay connected and join us for our upcoming church events."
-          titleClassName="text-primary-foreground"
-          subtitleClassName="text-primary-foreground"
-          descriptionClassName="text-primary-foreground"
-        />
+        <Reveal>
+          <SectionHeader
+            title="Upcoming Events"
+            subtitle="Events"
+            description="Stay connected and join us for our upcoming church events."
+            titleClassName="text-primary-foreground"
+            subtitleClassName="text-primary-foreground"
+            descriptionClassName="text-primary-foreground"
+          />
+        </Reveal>
 
-        <div className="flex flex-wrap justify-center gap-8">
+        <Stagger className="flex flex-wrap justify-center gap-8">
           {UPCOMING_EVENTS.map((event) => {
             return (
-              <div
+              <StaggerItem
                 key={event.id}
                 className="cursor-pointer flex h-[300px] w-full flex-row items-stretch sm:w-[calc(50%-(--spacing(8))/2)] lg:w-[calc(33.333%-(--spacing(8))/1.5)] max-w-[560px]"
               >
@@ -52,10 +55,10 @@ export default function UpcomingEvents() {
                   </p>
                   <CaretButton href="/events" text="View Event" aria-label={`Find out more about ${event.title} event`} />
                 </div>
-              </div>
+              </StaggerItem>
             );
           })}
-        </div>
+        </Stagger>
       </div>
     </section>
   );

--- a/components/homePage/sections/Welcome.tsx
+++ b/components/homePage/sections/Welcome.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import CaretButton from "@/components/ui/caret-button";
+import { Reveal } from "@/components/motion";
 import { CHURCH_INFO } from "@/lib/constants";
 
 export default function Welcome() {
@@ -8,7 +9,10 @@ export default function Welcome() {
   return (
     <section className="bg-muted-foreground/10">
       <div className="container max-w-500 pl-0 flex flex-col md:flex-row items-stretch gap-10">
-        <div className="md:w-1/2 relative h-[400px] md:h-auto">
+        <Reveal
+          variant="slide-right"
+          className="md:w-1/2 relative h-[400px] md:h-auto"
+        >
           <Image
             src="/images/church.png"
             alt="WCI Goderich Church Welcome"
@@ -17,8 +21,12 @@ export default function Welcome() {
             sizes="(max-width: 768px) 100vw, 50vw"
             priority
           />
-        </div>
-        <article className="md:w-1/2 py-20 flex flex-col gap-6 items-start px-4">
+        </Reveal>
+        <Reveal
+          as="article"
+          variant="slide-left"
+          className="md:w-1/2 py-20 flex flex-col gap-6 items-start px-4"
+        >
           <h2 className="uppercase text-sm text-foreground/90 font-light tracking-[0.4em]">
             Welcome to WCI Goderich
           </h2>
@@ -35,7 +43,7 @@ export default function Welcome() {
           </div>
 
           <CaretButton href="/about" text="Read More" aria-label="Find out more about our church" />
-        </article>
+        </Reveal>
       </div>
     </section>
   );

--- a/components/motion/AnimatedText.tsx
+++ b/components/motion/AnimatedText.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { motion, useReducedMotion } from "motion/react";
+import { cn } from "@/lib/utils";
+import { DURATION, EASE, VIEWPORT } from "@/lib/motion";
+
+interface AnimatedTextProps {
+  /** The text to animate, revealed word by word. */
+  text: string;
+  /** Delay between each word (seconds). @default 0.06 */
+  stagger?: number;
+  /** Delay before the first word animates (seconds). */
+  delay?: number;
+  /** Re-animate every time it enters the viewport. @default false */
+  repeat?: boolean;
+  className?: string;
+}
+
+const container = (stagger: number, delay: number) => ({
+  hidden: {},
+  visible: { transition: { staggerChildren: stagger, delayChildren: delay } },
+});
+
+const word = {
+  hidden: { opacity: 0, y: "0.4em" },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: DURATION.fast, ease: EASE.out },
+  },
+};
+
+/**
+ * Reveals a string word-by-word as it scrolls into view. Falls back to a
+ * static render when the user prefers reduced motion. Wraps in a span so it
+ * can sit inside any heading without changing layout semantics.
+ */
+export function AnimatedText({
+  text,
+  stagger = 0.06,
+  delay = 0,
+  repeat = false,
+  className,
+}: AnimatedTextProps) {
+  const reduceMotion = useReducedMotion();
+
+  if (reduceMotion) {
+    return <span className={cn(className)}>{text}</span>;
+  }
+
+  const words = text.split(" ");
+
+  return (
+    <motion.span
+      className={cn("inline-block", className)}
+      initial="hidden"
+      whileInView="visible"
+      viewport={{ once: !repeat, margin: VIEWPORT.margin }}
+      variants={container(stagger, delay)}
+      aria-label={text}
+    >
+      {words.map((w, i) => (
+        <motion.span
+          key={`${w}-${i}`}
+          className="inline-block whitespace-nowrap"
+          variants={word}
+          aria-hidden
+        >
+          {w}
+          {i < words.length - 1 ? " " : ""}
+        </motion.span>
+      ))}
+    </motion.span>
+  );
+}
+
+export default AnimatedText;

--- a/components/motion/Parallax.tsx
+++ b/components/motion/Parallax.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useRef } from "react";
+import {
+  motion,
+  useReducedMotion,
+  useScroll,
+  useTransform,
+  type HTMLMotionProps,
+} from "motion/react";
+import { cn } from "@/lib/utils";
+
+interface ParallaxProps extends HTMLMotionProps<"div"> {
+  /**
+   * How far the content drifts across the scroll, in px. Positive moves the
+   * element up as you scroll down. @default 60
+   */
+  amount?: number;
+  children: React.ReactNode;
+}
+
+/**
+ * Subtle scroll-linked parallax. The child drifts vertically as the wrapper
+ * passes through the viewport. Disabled under reduced-motion.
+ */
+export function Parallax({
+  amount = 60,
+  className,
+  children,
+  ...props
+}: ParallaxProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const reduceMotion = useReducedMotion();
+
+  const { scrollYProgress } = useScroll({
+    target: ref,
+    offset: ["start end", "end start"],
+  });
+  const y = useTransform(scrollYProgress, [0, 1], [amount, -amount]);
+
+  if (reduceMotion) {
+    return (
+      <div ref={ref} className={cn(className)}>
+        {children}
+      </div>
+    );
+  }
+
+  return (
+    <div ref={ref} className={cn("overflow-hidden", className)}>
+      <motion.div style={{ y }} {...props}>
+        {children}
+      </motion.div>
+    </div>
+  );
+}
+
+export default Parallax;

--- a/components/motion/Reveal.tsx
+++ b/components/motion/Reveal.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { motion, useReducedMotion, type HTMLMotionProps } from "motion/react";
+import { cn } from "@/lib/utils";
+import {
+  REDUCED_VARIANT,
+  VARIANTS,
+  VIEWPORT,
+  type RevealVariant,
+} from "@/lib/motion";
+
+type MotionTag = "div" | "section" | "article" | "span" | "li" | "ul" | "header";
+
+interface RevealProps extends Omit<HTMLMotionProps<"div">, "variants"> {
+  /** Which named entrance to use. @default "fade-up" */
+  variant?: RevealVariant;
+  /** Delay before the entrance starts (seconds). */
+  delay?: number;
+  /** Re-animate every time it enters the viewport. @default false (animate once) */
+  repeat?: boolean;
+  /** Rendered element. @default "div" */
+  as?: MotionTag;
+  children: React.ReactNode;
+}
+
+/**
+ * Wraps server-rendered content in a scroll-triggered entrance animation.
+ * Renders statically when the user prefers reduced motion.
+ */
+export function Reveal({
+  variant = "fade-up",
+  delay = 0,
+  repeat = false,
+  as = "div",
+  className,
+  children,
+  ...props
+}: RevealProps) {
+  const reduceMotion = useReducedMotion();
+  const MotionTag = motion[as] as typeof motion.div;
+
+  const variants = reduceMotion ? REDUCED_VARIANT : VARIANTS[variant];
+
+  return (
+    <MotionTag
+      className={cn(className)}
+      initial="hidden"
+      whileInView="visible"
+      viewport={{ once: !repeat, margin: VIEWPORT.margin }}
+      variants={variants}
+      transition={delay ? { delay } : undefined}
+      {...props}
+    >
+      {children}
+    </MotionTag>
+  );
+}
+
+export default Reveal;

--- a/components/motion/Stagger.tsx
+++ b/components/motion/Stagger.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { motion, useReducedMotion, type HTMLMotionProps } from "motion/react";
+import { cn } from "@/lib/utils";
+import {
+  REDUCED_VARIANT,
+  STAGGER_ITEM,
+  VIEWPORT,
+  staggerContainer,
+} from "@/lib/motion";
+
+type MotionTag = "div" | "section" | "ul" | "ol";
+
+interface StaggerProps extends Omit<HTMLMotionProps<"div">, "variants"> {
+  /** Delay between each child (seconds). @default 0.1 */
+  stagger?: number;
+  /** Delay before the first child animates (seconds). */
+  delayChildren?: number;
+  /** Re-animate every time it enters the viewport. @default false */
+  repeat?: boolean;
+  /** Rendered element. @default "div" */
+  as?: MotionTag;
+  children: React.ReactNode;
+}
+
+/**
+ * Container that animates its `StaggerItem` children in sequence as it
+ * scrolls into view. Wrap each item (e.g. a card) in `StaggerItem`.
+ */
+export function Stagger({
+  stagger = 0.1,
+  delayChildren = 0,
+  repeat = false,
+  as = "div",
+  className,
+  children,
+  ...props
+}: StaggerProps) {
+  const MotionTag = motion[as] as typeof motion.div;
+
+  return (
+    <MotionTag
+      className={cn(className)}
+      initial="hidden"
+      whileInView="visible"
+      viewport={{ once: !repeat, margin: VIEWPORT.margin }}
+      variants={staggerContainer(stagger, delayChildren)}
+      {...props}
+    >
+      {children}
+    </MotionTag>
+  );
+}
+
+interface StaggerItemProps extends Omit<HTMLMotionProps<"div">, "variants"> {
+  as?: "div" | "li" | "article" | "span";
+  children: React.ReactNode;
+}
+
+/** A single staggered child. Must be rendered inside a `Stagger`. */
+export function StaggerItem({
+  as = "div",
+  className,
+  children,
+  ...props
+}: StaggerItemProps) {
+  const reduceMotion = useReducedMotion();
+  const MotionTag = motion[as] as typeof motion.div;
+
+  return (
+    <MotionTag
+      className={cn(className)}
+      variants={reduceMotion ? REDUCED_VARIANT : STAGGER_ITEM}
+      {...props}
+    >
+      {children}
+    </MotionTag>
+  );
+}
+
+export default Stagger;

--- a/components/motion/index.ts
+++ b/components/motion/index.ts
@@ -1,0 +1,4 @@
+export { Reveal } from "./Reveal";
+export { Stagger, StaggerItem } from "./Stagger";
+export { AnimatedText } from "./AnimatedText";
+export { Parallax } from "./Parallax";

--- a/lib/cloudinary.ts
+++ b/lib/cloudinary.ts
@@ -5,7 +5,7 @@ import { v2 as cloudinary, type ResourceApiResponse } from "cloudinary";
  * `next build` can evaluate modules that import this file without credentials.
  */
 let configured = false;
-function ensureCloudinaryConfigured(): void {
+export function ensureCloudinaryConfigured(): void {
   if (configured) return;
 
   if (process.env.CLOUDINARY_URL) {
@@ -260,4 +260,3 @@ export async function listImagesFromFolder(
   }
 }
 
-export { cloudinary };

--- a/lib/constants/gallery.ts
+++ b/lib/constants/gallery.ts
@@ -5,9 +5,7 @@
 
 const CLOUDINARY_CLOUD_NAME =
   process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME ?? "";
-if (!CLOUDINARY_CLOUD_NAME && process.env.NODE_ENV !== "production") {
-  // Warn (don't throw) so builds succeed without env configured. Set
-  // NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME in .env.local for working gallery images.
+if (!CLOUDINARY_CLOUD_NAME) {
   console.warn(
     "[gallery] NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME is not set — gallery image URLs will be invalid until it is configured."
   );

--- a/lib/motion.ts
+++ b/lib/motion.ts
@@ -1,0 +1,95 @@
+import type { Variants, Transition } from "motion/react";
+
+/**
+ * Shared motion design tokens and variants.
+ * Single source of truth so every animated surface on the site feels consistent.
+ */
+
+/** Easing curves (cubic-bezier). */
+export const EASE = {
+  /** Smooth deceleration — the default for entrances. */
+  out: [0.22, 1, 0.36, 1],
+  /** Symmetric ease for loops / hovers. */
+  inOut: [0.65, 0, 0.35, 1],
+} as const;
+
+/** Durations in seconds. */
+export const DURATION = {
+  fast: 0.4,
+  base: 0.6,
+  slow: 0.9,
+} as const;
+
+/** Default travel distance (px) for slide/fade entrances. */
+export const DISTANCE = 24;
+
+/** Default viewport config for scroll-triggered reveals. */
+export const VIEWPORT = {
+  once: true,
+  /** Trigger slightly before the element is fully in view. */
+  margin: "0px 0px -12% 0px",
+} as const;
+
+const transition: Transition = { duration: DURATION.base, ease: EASE.out };
+
+/** Named entrance variants, keyed by `hidden` / `visible`. */
+export const VARIANTS = {
+  fade: {
+    hidden: { opacity: 0 },
+    visible: { opacity: 1, transition },
+  },
+  "fade-up": {
+    hidden: { opacity: 0, y: DISTANCE },
+    visible: { opacity: 1, y: 0, transition },
+  },
+  "fade-down": {
+    hidden: { opacity: 0, y: -DISTANCE },
+    visible: { opacity: 1, y: 0, transition },
+  },
+  "slide-left": {
+    hidden: { opacity: 0, x: DISTANCE },
+    visible: { opacity: 1, x: 0, transition },
+  },
+  "slide-right": {
+    hidden: { opacity: 0, x: -DISTANCE },
+    visible: { opacity: 1, x: 0, transition },
+  },
+  scale: {
+    hidden: { opacity: 0, scale: 0.94 },
+    visible: { opacity: 1, scale: 1, transition },
+  },
+  blur: {
+    hidden: { opacity: 0, filter: "blur(12px)" },
+    visible: { opacity: 1, filter: "blur(0px)", transition },
+  },
+} satisfies Record<string, Variants>;
+
+export type RevealVariant = keyof typeof VARIANTS;
+
+/** A no-op variant used when the user prefers reduced motion. */
+export const REDUCED_VARIANT: Variants = {
+  hidden: { opacity: 1 },
+  visible: { opacity: 1 },
+};
+
+/**
+ * Builds a stagger container variant. Children using `STAGGER_ITEM` (or any
+ * variant with `hidden`/`visible` keys) will animate in sequence.
+ */
+export function staggerContainer(
+  stagger = 0.1,
+  delayChildren = 0
+): Variants {
+  return {
+    hidden: {},
+    visible: {
+      transition: { staggerChildren: stagger, delayChildren },
+    },
+  };
+}
+
+/** Default per-item variant for staggered children. */
+export const STAGGER_ITEM: Variants = {
+  hidden: { opacity: 0, y: DISTANCE },
+  visible: { opacity: 1, y: 0, transition },
+};


### PR DESCRIPTION
## Summary

- Introduces a centralised animation library (`lib/motion.ts`) with shared easing, duration, distance tokens, and named Motion variants (`fade`, `fade-up`, `slide-left`, `slide-right`, `scale`, `blur`, `stagger`)
- Adds four reusable client-component primitives in `components/motion/`: `Reveal` (scroll-triggered entrance), `Stagger` / `StaggerItem` (cascading grid reveals), `AnimatedText` (word-by-word heading), and `Parallax` (scroll-linked drift)
- All primitives respect `prefers-reduced-motion` — they fall back to static/opacity-only render with no transforms
- Applies animations to every section on the homepage: hero, features, welcome, services, events, sermons, donation, gallery, birthdays, testimonies, and location
- Birthday section header uses `variant="fade"` (opacity-only) to avoid offsetting the rough-notation `Highlighter` stroke, which measures DOM position to draw

## Test plan

- [ ] Load homepage and verify each section animates in on scroll
- [ ] Check stagger timing on features, services, events, sermons, and birthday grids
- [ ] Verify birthday Highlighter stroke sits correctly on the heading after reveal
- [ ] Enable `prefers-reduced-motion` in OS settings — all sections should render statically with no transform animations
- [ ] Test on mobile and confirm viewport margins trigger at the right scroll depth

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added smooth entrance animations to home page sections with fade, slide, and scale effects
  * Implemented staggered animations for grid and list content
  * Added word-by-word text reveal animations
  * Introduced subtle parallax scroll effects throughout the page

* **Style**
  * Updated Featured Sermons card layout with refined typography

* **Chores**
  * Enhanced media upload configuration management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->