### PR TITLE
feat: animate about and contact pages, fix viewport trigger threshold

### DIFF
--- a/app/(routes)/about/Hero.tsx
+++ b/app/(routes)/about/Hero.tsx
@@ -4,6 +4,7 @@ import { useRef } from "react";
 import { AnimatedButton } from "@/components/ui/animated-button";
 import { VideoDialog, type VideoDialogRef } from "@/components/ui/video-dialog";
 import { ArrowDownIcon, PlayCircleIcon } from "@phosphor-icons/react";
+import { Reveal, Stagger, StaggerItem } from "@/components/motion";
 import { CHURCH_INFO } from "@/lib/constants";
 
 export default function HeroSection() {
@@ -16,7 +17,7 @@ export default function HeroSection() {
         <div className="relative min-h-screen flex-center">
           <div className="relative z-10 small-container">
             <div className="md:w-1/2">
-              <div>
+              <Reveal variant="fade-up">
                 <h1 className="max-w-md text-balance text-5xl font-medium md:text-6xl">
                   Welcome to Winners Chapel Int&apos;l Goderich
                 </h1>
@@ -43,28 +44,27 @@ export default function HeroSection() {
                     }}
                   />
                 </div>
-              </div>
+              </Reveal>
 
               <div className="mt-10">
                 <p className="text-muted-foreground">Our Core Values :</p>
-                <div className="mt-2 mr-1 grid grid-cols-3 gap-4">
+                <Stagger className="mt-2 mr-1 grid grid-cols-3 gap-4">
                   {CORE_VALUES.map((value, index) => (
-                    <div
-                      key={index}
-                      className="flex flex-col gap-2 border-l-2 border-muted-foreground/20 pl-2"
-                    >
-                      <h3 className="tracking-wider">{value.title}</h3>
-                      <p className="text-sm text-muted-foreground">
-                        {value.description}
-                      </p>
-                    </div>
+                    <StaggerItem key={index}>
+                      <div className="flex flex-col gap-2 border-l-2 border-muted-foreground/20 pl-2">
+                        <h3 className="tracking-wider">{value.title}</h3>
+                        <p className="text-sm text-muted-foreground">
+                          {value.description}
+                        </p>
+                      </div>
+                    </StaggerItem>
                   ))}
-                </div>
+                </Stagger>
               </div>
             </div>
           </div>
 
-          <div className="perspective-near mt-24 translate-x-12 md:absolute md:-right-6 md:bottom-16 md:left-1/2 md:top-40 md:mt-0 md:translate-x-0 md:z-20 max-[34rem]:hidden">
+          <Reveal variant="fade" className="perspective-near mt-24 translate-x-12 md:absolute md:-right-6 md:bottom-16 md:left-1/2 md:top-40 md:mt-0 md:translate-x-0 md:z-20 max-[34rem]:hidden">
             <div className="before:border-foreground/5 before:bg-foreground/5 relative h-full before:absolute before:-inset-x-4 before:bottom-7 before:top-0 before:skew-x-6 before:rounded-[calc(var(--radius)+1rem)] before:border before:pointer-events-none">
               <div className="bg-background rounded-(--radius) shadow-foreground/10 ring-foreground/5 relative h-full -translate-y-12 skew-x-6 overflow-hidden border border-transparent shadow-md ring-1">
                 <VideoDialog
@@ -79,7 +79,7 @@ export default function HeroSection() {
                 />
               </div>
             </div>
-          </div>
+          </Reveal>
         </div>
       </section>
     </main>

--- a/app/(routes)/about/Leadership.tsx
+++ b/app/(routes)/about/Leadership.tsx
@@ -6,6 +6,7 @@ import { LeadershipRole } from "@/lib/types/leadership";
 import { LEADERSHIP } from "@/lib/constants";
 import { cn } from "@/lib/utils";
 import { ImageWithRetry } from "@/components/ui/image-with-retry";
+import { Reveal, Stagger, StaggerItem } from "@/components/motion";
 
 const Leadership = () => {
   const { title, subtitle, description, PASTORS, DIRECTORS } = LEADERSHIP;
@@ -26,20 +27,22 @@ const Leadership = () => {
   return (
     <section id="leadership" className="bg-muted/30">
       <div className="small-container">
-        <SectionHeader
-          title={title}
-          subtitle={subtitle}
-          description={description}
-        />
+        <Reveal>
+          <SectionHeader
+            title={title}
+            subtitle={subtitle}
+            description={description}
+          />
+        </Reveal>
 
         <div className="mt-12 md:mt-24">
-          <div className="max-w-4xl mx-auto grid gap-x-6 gap-y-12 sm:grid-cols-2 lg:grid-cols-3">
+          <Stagger className="max-w-4xl mx-auto grid gap-x-6 gap-y-12 sm:grid-cols-2 lg:grid-cols-3">
             {leaders.map((leader, index) => {
               const leaderId = leader.id || `leader-${index}`;
               const isActive = activeLeaderId === leaderId;
 
               return (
-                <div
+                <StaggerItem
                   key={leaderId}
                   className="group overflow-hidden"
                   onMouseEnter={() => setActiveLeaderId(leaderId)}
@@ -51,6 +54,7 @@ const Leadership = () => {
                       prev === leaderId ? null : leaderId,
                     )
                   }
+                  as="div"
                 >
                   <ImageWithRetry
                     className={cn(
@@ -104,10 +108,10 @@ const Leadership = () => {
                       )}
                     </div>
                   </div>
-                </div>
+                </StaggerItem>
               );
             })}
-          </div>
+          </Stagger>
         </div>
       </div>
     </section>

--- a/app/(routes)/about/Ministries.tsx
+++ b/app/(routes)/about/Ministries.tsx
@@ -4,6 +4,7 @@ import SectionHeader from "@/components/SectionHeader";
 import { MINISTRIES } from "@/lib/constants";
 import { Badge } from "@/components/ui/badge";
 import Image from "next/image";
+import { Reveal, Stagger, StaggerItem } from "@/components/motion";
 
 export default function Ministries() {
   const { title, subtitle, description, ministries } = MINISTRIES;
@@ -15,24 +16,28 @@ export default function Ministries() {
   return (
     <section>
       <div className="small-container space-y-8 md:space-y-12" id="ministries">
-        <SectionHeader
-          title={title}
-          subtitle={subtitle}
-          description={description}
-          descriptionClassName="max-w-5xl"
-        />
+        <Reveal>
+          <SectionHeader
+            title={title}
+            subtitle={subtitle}
+            description={description}
+            descriptionClassName="max-w-5xl"
+          />
+        </Reveal>
 
-        <Image
-          className="rounded-(--radius) grayscale"
-          src="/images/ministries.jpeg"
-          alt="Church ministries team"
-          width={2940}
-          height={1960}
-        />
+        <Reveal variant="fade">
+          <Image
+            className="rounded-(--radius) grayscale"
+            src="/images/ministries.jpeg"
+            alt="Church ministries team"
+            width={2940}
+            height={1960}
+          />
+        </Reveal>
 
-        <div className="relative mx-auto grid grid-cols-2 gap-x-3 gap-y-6 sm:gap-8 lg:grid-cols-4">
+        <Stagger className="relative mx-auto grid grid-cols-2 gap-x-3 gap-y-6 sm:gap-8 lg:grid-cols-4">
           {filteredMinistries.map((ministry) => (
-            <div key={ministry?.id} className="space-y-3 cursor-pointer">
+            <StaggerItem key={ministry?.id} className="space-y-3 cursor-pointer">
               <div className="flex items-center gap-2">
                 <Zap className="size-4" />
                 <h3 className="text-sm font-medium">{ministry.title}</h3>
@@ -43,9 +48,9 @@ export default function Ministries() {
               <Badge variant="primary">
                 {ministry?.ageRange ?? "All Ages"}
               </Badge>
-            </div>
+            </StaggerItem>
           ))}
-        </div>
+        </Stagger>
       </div>
     </section>
   );

--- a/app/(routes)/about/MissionVision.tsx
+++ b/app/(routes)/about/MissionVision.tsx
@@ -1,6 +1,7 @@
 import SectionHeader from "@/components/SectionHeader";
 import CardDecorator from "@/components/ui/card-decorator";
-import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { CardContent, CardHeader } from "@/components/ui/card";
+import { Reveal, Stagger, StaggerItem } from "@/components/motion";
 import { CHURCH_INFO } from "@/lib/constants";
 import { IconComponent, ValidIconName } from "@/components/IconComponent";
 
@@ -32,32 +33,36 @@ export default function MissionVision() {
   return (
     <section id="mission-vision" className="bg-background">
       <div className="@container small-container max-w-5xl">
-        <SectionHeader
-          title="Mission, Vision and Mandate"
-          subtitle="About Us"
-          description={ABOUT_US[0]}
-          descriptionClassName="mb-8 max-w-5xl"
-          additionalText={ABOUT_US[1]}
-        />
-        <Card className="@min-4xl:max-w-full @min-4xl:grid-cols-3 @min-4xl:divide-x @min-4xl:divide-y-0 mx-auto mt-8 grid max-w-sm divide-y overflow-hidden shadow-zinc-950/5 *:text-center md:mt-16 bg-background py-0 *:py-6">
-          {missionVisionCards.map((card) => <div key={card.title} className="group shadow-zinc-950/5">
-            <CardHeader className="pb-3">
-              <CardDecorator>
-                <IconComponent
-                  iconName={card.icon}
-                  size={32}
-                  weight="duotone"
-                  className="text-foreground"
-                />
-              </CardDecorator>
-              <h3 className="mt-4 font-medium">{card.title}</h3>
-            </CardHeader>
+        <Reveal>
+          <SectionHeader
+            title="Mission, Vision and Mandate"
+            subtitle="About Us"
+            description={ABOUT_US[0]}
+            descriptionClassName="mb-8 max-w-5xl"
+            additionalText={ABOUT_US[1]}
+          />
+        </Reveal>
+        <Stagger className="@min-4xl:max-w-full @min-4xl:grid-cols-3 @min-4xl:divide-x @min-4xl:divide-y-0 mx-auto mt-8 grid max-w-sm divide-y overflow-hidden shadow-zinc-950/5 *:text-center md:mt-16 bg-background py-0 *:py-6 rounded-xl border">
+          {missionVisionCards.map((card) => (
+            <StaggerItem key={card.title} className="group shadow-zinc-950/5">
+              <CardHeader className="pb-3">
+                <CardDecorator>
+                  <IconComponent
+                    iconName={card.icon}
+                    size={32}
+                    weight="duotone"
+                    className="text-foreground"
+                  />
+                </CardDecorator>
+                <h3 className="mt-4 font-medium">{card.title}</h3>
+              </CardHeader>
 
-            <CardContent>
-              <p className="text-sm">{card.description}</p>
-            </CardContent>
-          </div>)}
-        </Card>
+              <CardContent>
+                <p className="text-sm">{card.description}</p>
+              </CardContent>
+            </StaggerItem>
+          ))}
+        </Stagger>
       </div>
     </section>
   );

--- a/app/(routes)/about/Pillars.tsx
+++ b/app/(routes)/about/Pillars.tsx
@@ -6,6 +6,7 @@ import {
   AccordionTrigger,
 } from "@/components/ui/accordion";
 import { Badge } from "@/components/ui/badge";
+import { Reveal } from "@/components/motion";
 import { CHURCH_INFO } from "@/lib/constants";
 
 const Pillars = () => {
@@ -15,15 +16,17 @@ const Pillars = () => {
   return (
     <section className="bg-muted/30">
       <div className="small-container">
-        <SectionHeader
-          title={title}
-          subtitle={subtitle}
-          description={description[0]}
-          descriptionClassName="mb-8 max-w-5xl"
-          additionalText={description[1]}
-        />
+        <Reveal>
+          <SectionHeader
+            title={title}
+            subtitle={subtitle}
+            description={description[0]}
+            descriptionClassName="mb-8 max-w-5xl"
+            additionalText={description[1]}
+          />
+        </Reveal>
 
-        <div className="mt-12 md:mt-24">
+        <Reveal variant="fade-up" className="mt-12 md:mt-24">
           <Accordion
             className="max-w-6xl mx-auto grid gap-6 sm:grid-cols-2 lg:grid-cols-3 items-start"
             defaultValue={["1", "2", "3"]}
@@ -48,7 +51,7 @@ const Pillars = () => {
                 </AccordionTrigger>
                 <AccordionContent className="pb-2 pt-4 text-muted-foreground flex flex-col gap-4">
                   <p className="text-sm text-muted-foreground leading-relaxed grow">
-                    "{pillar.description}"
+                    &ldquo;{pillar.description}&rdquo;
                   </p>
                   <div className="pt-2 border-t">
                     <p className="text-xs font-medium text-muted-foreground mb-2">
@@ -71,7 +74,7 @@ const Pillars = () => {
               </AccordionItem>
             ))}
           </Accordion>
-        </div>
+        </Reveal>
       </div>
     </section>
   );

--- a/app/(routes)/contact-us/ContactForm.tsx
+++ b/app/(routes)/contact-us/ContactForm.tsx
@@ -23,6 +23,7 @@ import {
 import { PaperPlaneTiltIcon } from "@phosphor-icons/react";
 import { LeadershipRole } from "@/lib/types/leadership";
 import { CHURCH_INFO, LEADERSHIP } from "@/lib/constants";
+import { Reveal } from "@/components/motion";
 
 type ContactFormValues = {
   name: string;
@@ -202,13 +203,15 @@ export default function ContactForm() {
   return (
     <section className="bg-muted">
       <div className="small-container max-w-4xl">
-        <SectionHeader
-          title="How can we help you?"
-          subtitle="Contact Us"
-          description="We'd love to hear from you. Whether you have a question, prayer request, or just want to connect, we're here to help."
-        />
+        <Reveal>
+          <SectionHeader
+            title="How can we help you?"
+            subtitle="Contact Us"
+            description="We'd love to hear from you. Whether you have a question, prayer request, or just want to connect, we're here to help."
+          />
+        </Reveal>
         <div className="mt-12 grid gap-12 lg:grid-cols-3">
-          <div className="grid grid-cols-2 gap-6 lg:block lg:space-y-12">
+          <Reveal variant="slide-right" className="grid grid-cols-2 gap-6 lg:block lg:space-y-12">
             <div className="flex flex-col justify-between space-y-6">
               <div>
                 <h2 className="mb-3 text-lg">Church Office</h2>
@@ -235,8 +238,9 @@ export default function ContactForm() {
                 </div>
               </div>
             )}
-          </div>
+          </Reveal>
 
+          <Reveal variant="slide-left" className="lg:col-span-2">
           <form
             onSubmit={form.handleSubmit(onSubmit, (errors) => {
               // Show toast when form validation fails
@@ -252,7 +256,7 @@ export default function ContactForm() {
                 });
               }
             })}
-            className="@container lg:col-span-2"
+            className="@container"
           >
             <Card className="p-8 sm:p-12">
               <div className="flex flex-col gap-4">
@@ -366,6 +370,7 @@ export default function ContactForm() {
               </div>
             </Card>
           </form>
+          </Reveal>
         </div>
       </div>
     </section>

--- a/app/(routes)/contact-us/Faqs.tsx
+++ b/app/(routes)/contact-us/Faqs.tsx
@@ -9,6 +9,7 @@ import {
 import Link from "next/link";
 import { FAQS } from "@/lib/constants";
 import SectionHeader from "@/components/SectionHeader";
+import { Reveal } from "@/components/motion";
 
 export default function Faqs() {
   const { title, subtitle, description, questions } = FAQS;
@@ -17,14 +18,14 @@ export default function Faqs() {
     <section>
       <div className="small-container max-w-5xl">
         <div className="grid gap-8 md:grid-cols-5 md:gap-12">
-          <div className="md:col-span-2">
+          <Reveal variant="slide-right" className="md:col-span-2">
             <SectionHeader
               title={title}
               description={description}
               className="text-left"
             />
-          </div>
-          <div className="md:col-span-3">
+          </Reveal>
+          <Reveal variant="slide-left" className="md:col-span-3">
             <Accordion
               type="single"
               defaultValue={String(questions[0].id)}
@@ -59,7 +60,7 @@ export default function Faqs() {
               </Link>{" "}
               below
             </p>
-          </div>
+          </Reveal>
         </div>
       </div>
     </section>

--- a/app/(routes)/contact-us/page.tsx
+++ b/app/(routes)/contact-us/page.tsx
@@ -2,6 +2,7 @@ import { Spotlight } from "@/components/ui/spotlight";
 import Faqs from "./Faqs";
 import ContactForm from "./ContactForm";
 import CtaSection from "@/components/CtaSection";
+import { Reveal } from "@/components/motion";
 
 const ContactUsPage = () => {
   return (
@@ -14,7 +15,7 @@ const ContactUsPage = () => {
           className="-top-1/5 -left-1/7 md:-top-1/4 md:left-1/6"
           fill="#fdfcfb"
         />
-        <div className="relative max-w-7xl mx-auto px-4 text-center">
+        <Reveal variant="fade-up" className="relative max-w-7xl mx-auto px-4 text-center">
           <h1 className="text-5xl md:text-6xl font-bold mb-6 bg-linear-to-r from-white to-slate-200 bg-clip-text text-transparent">
             Get in Touch
           </h1>
@@ -22,7 +23,7 @@ const ContactUsPage = () => {
             We&apos;d love to hear from you and help answer any questions you
             may have
           </p>
-        </div>
+        </Reveal>
       </section>
       <Faqs />
       <ContactForm />

--- a/components/CtaSection.tsx
+++ b/components/CtaSection.tsx
@@ -1,5 +1,6 @@
 import SectionHeader from "@/components/SectionHeader";
 import CtaContainer from "./CtaContainer";
+import { Reveal } from "@/components/motion";
 import { cn } from "@/lib/utils";
 import { SmoothScrollOptions } from "@/lib/utils/smoothScroll";
 
@@ -27,7 +28,7 @@ export default function CtaSection({
   containerClassName,
 }: CtaSectionProps) {
   return (
-    <div className={cn("small-container max-w-4xl text-center", className)}>
+    <Reveal className={cn("small-container max-w-4xl text-center", className)}>
       <SectionHeader title={title} description={description} />
 
       <CtaContainer
@@ -35,6 +36,6 @@ export default function CtaSection({
         containerClassName={containerClassName}
         buttons={buttons}
       />
-    </div>
+    </Reveal>
   );
 }

--- a/components/CtaSection.tsx
+++ b/components/CtaSection.tsx
@@ -28,7 +28,7 @@ export default function CtaSection({
   containerClassName,
 }: CtaSectionProps) {
   return (
-    <Reveal className={cn("small-container max-w-4xl text-center", className)}>
+    <Reveal repeat className={cn("small-container max-w-4xl text-center", className)}>
       <SectionHeader title={title} description={description} />
 
       <CtaContainer

--- a/components/motion/Reveal.tsx
+++ b/components/motion/Reveal.tsx
@@ -46,7 +46,7 @@ export function Reveal({
       className={cn(className)}
       initial="hidden"
       whileInView="visible"
-      viewport={{ once: !repeat, margin: VIEWPORT.margin }}
+      viewport={{ ...VIEWPORT, once: !repeat }}
       variants={variants}
       transition={delay ? { delay } : undefined}
       {...props}

--- a/components/motion/Stagger.tsx
+++ b/components/motion/Stagger.tsx
@@ -43,7 +43,7 @@ export function Stagger({
       className={cn(className)}
       initial="hidden"
       whileInView="visible"
-      viewport={{ once: !repeat, margin: VIEWPORT.margin }}
+      viewport={{ ...VIEWPORT, once: !repeat }}
       variants={staggerContainer(stagger, delayChildren)}
       {...props}
     >

--- a/lib/motion.ts
+++ b/lib/motion.ts
@@ -26,8 +26,10 @@ export const DISTANCE = 24;
 /** Default viewport config for scroll-triggered reveals. */
 export const VIEWPORT = {
   once: true,
-  /** Trigger slightly before the element is fully in view. */
-  margin: "0px 0px -12% 0px",
+  /** At least 15% of the element must be visible before triggering — prevents
+   *  false positives during page load / scroll restoration. */
+  amount: 0.15,
+  margin: "0px 0px -8% 0px",
 } as const;
 
 const transition: Transition = { duration: DURATION.base, ease: EASE.out };


### PR DESCRIPTION
## Summary

- Animates all sections on the **About** page: hero (fade-up heading + staggered core values), mission/vision cards (staggered), pillars accordion (fade-up block), ministries grid (staggered), leadership cards (staggered)
- Animates all sections on the **Contact** page: hero heading, FAQs (two-column slide-in), contact form info panel + form card (slide-in from opposite sides)
- Adds reveal animation to the shared `CtaSection` component with `repeat` mode so it animates fresh on every page it appears — prevents the "animated once, never again" issue across navigation
- Fixes premature animation trigger: viewport detection now requires 15% of the element to be visible before firing, preventing false positives during page load and scroll restoration

## Test plan
- [ ] Scroll through About page — hero, mission cards, pillars, ministries, and leadership all animate in
- [ ] Scroll through Contact page — FAQs and form slide in from opposite sides
- [ ] Navigate between pages (Home → About → Contact) — CTA section should animate on each page independently
- [ ] Elements should not animate before they are scrolled into view
