### PR TITLE
feat: animate giving and prayer pages

### DIFF
--- a/app/(routes)/giving/GivingDetails.tsx
+++ b/app/(routes)/giving/GivingDetails.tsx
@@ -16,6 +16,7 @@ import { cn } from "@/lib/utils";
 import { WordRotate } from "@/components/ui/word-rotate";
 import SectionHeader from "@/components/SectionHeader";
 import { Badge } from "@/components/ui/badge";
+import { Reveal } from "@/components/motion";
 
 export default function GivingDetails() {
   const [copiedField, setCopiedField] = useState<string | null>(null);
@@ -96,17 +97,20 @@ export default function GivingDetails() {
   return (
     <section id="account-details" className="bg-muted/30">
       <div className="small-container max-w-4xl">
-        <SectionHeader
-          title={<WordRotate
-            words={GIVE_NOW}
-            className="text-4xl md:text-5xl font-semibold leading-tight tracking-tight mb-6 bg-linear-to-br from-[#f59e0b] via-primary to-accent bg-clip-text text-transparent"
-            duration={2500}
-            pauseDuration={500}
-          />}
-          subtitle="Give Now"
-          description="Use the account details below to make your transfer. Click on any detail to copy it to your clipboard."
-        />
+        <Reveal>
+          <SectionHeader
+            title={<WordRotate
+              words={GIVE_NOW}
+              className="text-4xl md:text-5xl font-semibold leading-tight tracking-tight mb-6 bg-linear-to-br from-[#f59e0b] via-primary to-accent bg-clip-text text-transparent"
+              duration={2500}
+              pauseDuration={500}
+            />}
+            subtitle="Give Now"
+            description="Use the account details below to make your transfer. Click on any detail to copy it to your clipboard."
+          />
+        </Reveal>
 
+        <Reveal variant="fade-up">
         <Card className="mb-8">
           <CardHeader>
             <CardTitle className="text-2xl">Bank Account Details</CardTitle>
@@ -181,6 +185,7 @@ export default function GivingDetails() {
             className="mb-4"
           />
         </div>
+        </Reveal>
       </div>
     </section>
   );

--- a/app/(routes)/giving/GivingInfo.tsx
+++ b/app/(routes)/giving/GivingInfo.tsx
@@ -8,6 +8,7 @@ import {
   CardHeader,
 } from "@/components/ui/card";
 import { IconComponent, ValidIconName } from "@/components/IconComponent";
+import { Reveal, Stagger, StaggerItem } from "@/components/motion";
 
 const infoCards: Array<{
   icon: ValidIconName;
@@ -39,30 +40,31 @@ export default function GivingInfo() {
   return (
     <section id="giving">
       <div className="@container small-container">
-        <SectionHeader
-          title="About Giving"
-          subtitle="Ways to Support"
-          description="Learn more about how you can partner with us in advancing God's kingdom through your generous giving"
-        />
+        <Reveal>
+          <SectionHeader
+            title="About Giving"
+            subtitle="Ways to Support"
+            description="Learn more about how you can partner with us in advancing God's kingdom through your generous giving"
+          />
+        </Reveal>
 
-        <div className="@min-4xl:max-w-full @min-4xl:grid-cols-3 mx-auto mt-8 grid max-w-sm gap-6 [--color-background:var(--color-muted)] [--color-card:var(--color-muted)] *:text-center md:mt-16 dark:[--color-muted:var(--color-zinc-900)]">
+        <Stagger className="@min-4xl:max-w-full @min-4xl:grid-cols-3 mx-auto mt-8 grid max-w-sm gap-6 [--color-background:var(--color-muted)] [--color-card:var(--color-muted)] *:text-center md:mt-16 dark:[--color-muted:var(--color-zinc-900)]">
           {infoCards.map((info, index) => (
-            <Card
-              key={index}
-              className="group border-0 shadow-none bg-background"
-            >
-              <CardHeader>
-                <CardDecorator>
-                  <IconComponent iconName={info.icon} className="text-foreground" size={32} weight="duotone" />
-                </CardDecorator>
-                <h3 className="font-medium">{info.title}</h3>
-              </CardHeader>
-              <CardContent>
-                <p className="text-sm">{info.description}</p>
-              </CardContent>
-            </Card>
+            <StaggerItem key={index}>
+              <Card className="group border-0 shadow-none bg-background h-full">
+                <CardHeader>
+                  <CardDecorator>
+                    <IconComponent iconName={info.icon} className="text-foreground" size={32} weight="duotone" />
+                  </CardDecorator>
+                  <h3 className="font-medium">{info.title}</h3>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-sm">{info.description}</p>
+                </CardContent>
+              </Card>
+            </StaggerItem>
           ))}
-        </div>
+        </Stagger>
       </div>
     </section>
   );

--- a/app/(routes)/giving/LivingFaithWorldwide.tsx
+++ b/app/(routes)/giving/LivingFaithWorldwide.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/card";
 import { AnimatedButton } from "@/components/ui/animated-button";
 import { ArrowSquareOutIcon } from "@phosphor-icons/react";
+import { Reveal, Stagger, StaggerItem } from "@/components/motion";
 
 const worldwideGivingOptions: Array<{
   icon: ValidIconName;
@@ -41,36 +42,37 @@ export default function LivingFaithWorldwide() {
   return (
     <section className="bg-linear-to-br from-foreground/5 to-background">
       <div className="small-container max-w-4xl">
-        <SectionHeader
-          title="Give to Living Faith Church Worldwide"
-          subtitle="International Giving"
-          description="Support the global mission and vision of Living Faith Church Worldwide International. Your giving helps advance God's kingdom through various impactful projects and initiatives."
-        />
+        <Reveal>
+          <SectionHeader
+            title="Give to Living Faith Church Worldwide"
+            subtitle="International Giving"
+            description="Support the global mission and vision of Living Faith Church Worldwide International. Your giving helps advance God's kingdom through various impactful projects and initiatives."
+          />
+        </Reveal>
 
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
+        <Stagger className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
           {worldwideGivingOptions.map((option) => (
-            <Card
-              key={option.title}
-              className="group border-0 hover:shadow-primary/20 hover:shadow-sm transition-all duration-300 flex flex-col"
-            >
-              <CardHeader>
-                <div className="p-2 rounded-lg bg-primary/10 text-primary w-fit mb-2">
-                  <IconComponent
-                    iconName={option.icon}
-                    size={24}
-                    weight="duotone"
-                  />
-                </div>
-                <CardTitle className="text-lg">{option.title}</CardTitle>
-              </CardHeader>
-              <CardContent className="flex-1">
-                <CardDescription className="text-sm">
-                  {option.description}
-                </CardDescription>
-              </CardContent>
-            </Card>
+            <StaggerItem key={option.title} className="flex">
+              <Card className="group border-0 hover:shadow-primary/20 hover:shadow-sm transition-all duration-300 flex flex-col w-full">
+                <CardHeader>
+                  <div className="p-2 rounded-lg bg-primary/10 text-primary w-fit mb-2">
+                    <IconComponent
+                      iconName={option.icon}
+                      size={24}
+                      weight="duotone"
+                    />
+                  </div>
+                  <CardTitle className="text-lg">{option.title}</CardTitle>
+                </CardHeader>
+                <CardContent className="flex-1">
+                  <CardDescription className="text-sm">
+                    {option.description}
+                  </CardDescription>
+                </CardContent>
+              </Card>
+            </StaggerItem>
           ))}
-        </div>
+        </Stagger>
 
         <div className="text-center">
           <AnimatedButton

--- a/app/(routes)/prayer/AnsweredPrayers.tsx
+++ b/app/(routes)/prayer/AnsweredPrayers.tsx
@@ -1,6 +1,7 @@
 import SectionHeader from "@/components/SectionHeader";
 import { AnsweredPrayerCarousel } from "@/app/(routes)/prayer/AnsweredPrayerCarousel";
 import { getTestimoniesServer } from "@/lib/data/testimonies.server";
+import { Reveal } from "@/components/motion";
 
 export default async function AnsweredPrayers() {
   // Fetch testimonies filtered by category "prayer" or "miracles"
@@ -21,11 +22,13 @@ export default async function AnsweredPrayers() {
   return (
     <section className="bg-muted">
       <div className="small-container">
-        <SectionHeader
-          subtitle="Answered Prayers"
-          title="Testimonies of God's Faithfulness"
-          description="See how God has answered prayers in the lives of our members. These testimonies serve as encouragement and proof that prayer works."
-        />
+        <Reveal>
+          <SectionHeader
+            subtitle="Answered Prayers"
+            title="Testimonies of God's Faithfulness"
+            description="See how God has answered prayers in the lives of our members. These testimonies serve as encouragement and proof that prayer works."
+          />
+        </Reveal>
         <div>
           {testimonies.length === 0 ? (
             <div className="text-center py-12">

--- a/app/(routes)/prayer/JoinPrayerGroup.tsx
+++ b/app/(routes)/prayer/JoinPrayerGroup.tsx
@@ -21,6 +21,7 @@ import {
   UsersIcon,
 } from "@phosphor-icons/react";
 import { cn } from "@/lib/utils";
+import { Reveal } from "@/components/motion";
 import {
   MIDNIGHT_PRAYER_GROUPS,
   UNIQUE_PRAYER_SESSIONS,
@@ -191,7 +192,7 @@ export default function JoinPrayerGroup() {
 
   return (
     <div id="join-group" className="grid gap-12 lg:grid-cols-4 items-start">
-      <div className="grid min-[400px]:grid-cols-2 gap-4 lg:col-span-2">
+      <Reveal variant="slide-right" className="grid min-[400px]:grid-cols-2 gap-4 lg:col-span-2">
         <div className="mb-8 col-span-2">
           <div className="flex items-center gap-2 mb-6">
             <ClockIcon size={24} weight="duotone" className="text-primary" />
@@ -274,7 +275,8 @@ export default function JoinPrayerGroup() {
             </div>
           );
         })}
-      </div>
+      </Reveal>
+      <Reveal variant="slide-left" className="lg:col-span-2">
       <form
         onSubmit={form.handleSubmit(onSubmit, (errors) => {
           // Show toast when form validation fails
@@ -290,7 +292,7 @@ export default function JoinPrayerGroup() {
             });
           }
         })}
-        className="@container lg:col-span-2"
+        className="@container"
       >
         <Card className="p-8">
           <div className="flex flex-col gap-4">
@@ -354,6 +356,7 @@ export default function JoinPrayerGroup() {
           </div>
         </Card>
       </form>
+      </Reveal>
     </div>
   );
 }

--- a/app/(routes)/prayer/PrayerInspiration.tsx
+++ b/app/(routes)/prayer/PrayerInspiration.tsx
@@ -8,39 +8,41 @@ import {
 } from "@/components/ui/card";
 import { PRAYER_INSPIRATIONS } from "@/lib/constants";
 import { IconComponent, ValidIconName } from "@/components/IconComponent";
+import { Reveal, Stagger, StaggerItem } from "@/components/motion";
 
 export default function PrayerInspiration() {
   return (
     <section className="py-16 md:py-32">
       <div className="@container mx-auto max-w-5xl px-6">
-        <SectionHeader
-          title="The Power of Prayer"
-          subtitle="Prayer Inspiration"
-          description="Prayer is far more than a religious ritual or a spiritual practice—it is the very heartbeat of our relationship with God. Through prayer, we open ourselves to divine transformation, inviting God's wisdom, peace, and power into every aspect of our lives. Whether we come before Him with thanksgiving, petition, or simply to be still in His presence, prayer becomes the bridge that connects our finite human experience with His infinite grace and love. It is in these sacred moments of communion that we find strength for our journey, clarity for our decisions, and the comfort of knowing we are never alone. Prayer changes not only our circumstances but, more importantly, it changes us—molding our hearts, refining our character, and drawing us ever closer to the One who hears and answers according to His perfect will."
-        />
-        <div className="@min-4xl:max-w-full @min-4xl:grid-cols-3 mx-auto mt-8 grid max-w-sm gap-6 [--color-background:var(--color-muted)] [--color-card:var(--color-muted)] *:text-center md:mt-16 dark:[--color-muted:var(--color-zinc-900)]">
+        <Reveal>
+          <SectionHeader
+            title="The Power of Prayer"
+            subtitle="Prayer Inspiration"
+            description="Prayer is far more than a religious ritual or a spiritual practice—it is the very heartbeat of our relationship with God. Through prayer, we open ourselves to divine transformation, inviting God's wisdom, peace, and power into every aspect of our lives. Whether we come before Him with thanksgiving, petition, or simply to be still in His presence, prayer becomes the bridge that connects our finite human experience with His infinite grace and love. It is in these sacred moments of communion that we find strength for our journey, clarity for our decisions, and the comfort of knowing we are never alone. Prayer changes not only our circumstances but, more importantly, it changes us—molding our hearts, refining our character, and drawing us ever closer to the One who hears and answers according to His perfect will."
+          />
+        </Reveal>
+        <Stagger className="@min-4xl:max-w-full @min-4xl:grid-cols-3 mx-auto mt-8 grid max-w-sm gap-6 [--color-background:var(--color-muted)] [--color-card:var(--color-muted)] *:text-center md:mt-16 dark:[--color-muted:var(--color-zinc-900)]">
           {PRAYER_INSPIRATIONS.map((inspiration) => (
-            <Card
-              key={inspiration.title}
-              className="group border-0 shadow-none bg-background"
-            >
-              <CardHeader>
-                <CardDecorator>
-                  <IconComponent iconName={inspiration.icon as ValidIconName} size={32} weight="duotone" className="text-foreground" aria-hidden />
-                </CardDecorator>
-                <h3 className="font-medium">{inspiration.title}</h3>
-              </CardHeader>
-              <CardContent>
-                <p className="text-sm">{inspiration.description}</p>
-              </CardContent>
-              <CardFooter>
-                <blockquote className="text-sm italic text-primary">
-                  {inspiration.verse}
-                </blockquote>
-              </CardFooter>
-            </Card>
+            <StaggerItem key={inspiration.title}>
+              <Card className="group border-0 shadow-none bg-background h-full">
+                <CardHeader>
+                  <CardDecorator>
+                    <IconComponent iconName={inspiration.icon as ValidIconName} size={32} weight="duotone" className="text-foreground" aria-hidden />
+                  </CardDecorator>
+                  <h3 className="font-medium">{inspiration.title}</h3>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-sm">{inspiration.description}</p>
+                </CardContent>
+                <CardFooter>
+                  <blockquote className="text-sm italic text-primary">
+                    {inspiration.verse}
+                  </blockquote>
+                </CardFooter>
+              </Card>
+            </StaggerItem>
           ))}
-        </div>
+        </Stagger>
       </div>
     </section>
   );

--- a/app/(routes)/prayer/PrayerPoints.tsx
+++ b/app/(routes)/prayer/PrayerPoints.tsx
@@ -9,6 +9,7 @@ import { FilterTabs, type TabConfig } from "@/components/ui/filter-tabs";
 import { BookOpenIcon } from "@phosphor-icons/react";
 import { PRAYER_POINTS } from "@/lib/constants";
 import { formatOrdinal } from "@/lib/utils";
+import { Reveal } from "@/components/motion";
 
 interface PrayerPointsProps {
   initialCategory?: string;
@@ -153,11 +154,13 @@ export default function PrayerPoints({ initialCategory }: PrayerPointsProps) {
   return (
     <section>
       <div className="small-container">
-        <SectionHeader
-          title="Prayer Points"
-          subtitle="Guided Prayer"
-          description="Use these prayer points to guide your prayer time. We especially focus on our weekly midnight prayer groups that meet to intercede for breakthrough and victory."
-        />
+        <Reveal>
+          <SectionHeader
+            title="Prayer Points"
+            subtitle="Guided Prayer"
+            description="Use these prayer points to guide your prayer time. We especially focus on our weekly midnight prayer groups that meet to intercede for breakthrough and victory."
+          />
+        </Reveal>
 
         <div className="mt-12">
           <FilterTabs

--- a/app/(routes)/prayer/PrayerRequestForm.tsx
+++ b/app/(routes)/prayer/PrayerRequestForm.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/components/ui/field";
 import { PaperPlaneTiltIcon } from "@phosphor-icons/react";
 import { CHURCH_INFO, PRAYER_CATEGORIES } from "@/lib/constants";
+import { Reveal } from "@/components/motion";
 
 type PrayerRequestFormValues = {
   name: string;
@@ -225,13 +226,15 @@ export default function PrayerRequestForm() {
       className="bg-linear-to-b from-muted to-background"
     >
       <div className="small-container max-w-4xl">
-        <SectionHeader
-          title="We're Here to Pray With You"
-          subtitle="Prayer Request"
-          description="Share your prayer needs with us. Our prayer team is committed to interceding on your behalf. Your request will be handled with care and confidentiality."
-        />
+        <Reveal>
+          <SectionHeader
+            title="We're Here to Pray With You"
+            subtitle="Prayer Request"
+            description="Share your prayer needs with us. Our prayer team is committed to interceding on your behalf. Your request will be handled with care and confidentiality."
+          />
+        </Reveal>
         <div className="mt-12 grid gap-12 lg:grid-cols-3">
-          <div className="grid grid-cols-2 gap-6 lg:block lg:space-y-12">
+          <Reveal variant="slide-right" className="grid grid-cols-2 gap-6 lg:block lg:space-y-12">
             <div className="flex flex-col justify-between space-y-6">
               <div>
                 <h2 className="mb-3 text-lg">Church Office</h2>
@@ -255,7 +258,8 @@ export default function PrayerRequestForm() {
                 our services.
               </p>
             </div>
-          </div>
+          </Reveal>
+          <Reveal variant="slide-left" className="lg:col-span-2">
           <form
             onSubmit={form.handleSubmit(onSubmit, (errors) => {
               // Show toast when form validation fails
@@ -271,7 +275,7 @@ export default function PrayerRequestForm() {
                 });
               }
             })}
-            className="@container lg:col-span-2"
+            className="@container"
           >
             <Card className="p-8 sm:p-12">
               <div className="flex flex-col gap-4">
@@ -381,6 +385,7 @@ export default function PrayerRequestForm() {
               </div>
             </Card>
           </form>
+          </Reveal>
         </div>
       </div>
     </section>

--- a/app/(routes)/prayer/PrayerSessions.tsx
+++ b/app/(routes)/prayer/PrayerSessions.tsx
@@ -6,64 +6,68 @@ import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { ClockIcon, MapPinIcon, CalendarIcon } from "@phosphor-icons/react";
 import { PRAYER_SESSIONS } from "@/lib/constants";
+import { Reveal, Stagger, StaggerItem } from "@/components/motion";
 
 export default function PrayerSessions() {
 
   return (
     <section id="prayer-sessions" className="bg-muted">
       <div className="small-container">
-        <SectionHeader
-          title="Prayer Sessions & Services"
-          subtitle="Join Us in Prayer"
-          description="Find a prayer session that fits your schedule. We have various prayer groups and services throughout the week, including special midnight prayer groups."
-        />
+        <Reveal>
+          <SectionHeader
+            title="Prayer Sessions & Services"
+            subtitle="Join Us in Prayer"
+            description="Find a prayer session that fits your schedule. We have various prayer groups and services throughout the week, including special midnight prayer groups."
+          />
+        </Reveal>
         <JoinPrayerGroup />
 
         {/* Regular Prayer Sessions (including adapted services) */}
         <div className="mt-12">
-          <h3 className="mb-6">All Prayer Sessions</h3>
-          <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          <Reveal>
+            <h3 className="mb-6">All Prayer Sessions</h3>
+          </Reveal>
+          <Stagger className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
             {PRAYER_SESSIONS.map((session) => (
-              <Card
-                key={session.id}
-                className="p-6 transition-all duration-300 shadow-sm hover:shadow-primary/20 hover:shadow-md overflow-hidden"
-              >
-                <div className="flex items-start justify-between">
-                  <h4 className="text-lg">{session.name}</h4>
-                  <Badge variant="outline" className="capitalize">
-                    {session.type}
-                  </Badge>
-                </div>
-                <p className="text-sm text-muted-foreground">
-                  {session.description}
-                </p>
-                <div className="space-y-2">
-                  <div className="flex items-center gap-2">
-                    <CalendarIcon size={16} className="text-primary" />
-                    <span className="text-sm">{session.day}</span>
+              <StaggerItem key={session.id} className="flex">
+                <Card className="p-6 transition-all duration-300 shadow-sm hover:shadow-primary/20 hover:shadow-md overflow-hidden w-full">
+                  <div className="flex items-start justify-between">
+                    <h4 className="text-lg">{session.name}</h4>
+                    <Badge variant="outline" className="capitalize">
+                      {session.type}
+                    </Badge>
                   </div>
-                  <div className="flex items-center gap-2">
-                    <ClockIcon size={16} className="text-primary" />
-                    <div className="flex flex-wrap gap-1">
-                      {session.times.map((time, index) => (
-                        <Badge
-                          key={index}
-                          variant="outline"
-                          className="text-xs"
-                        >
-                          {time}
-                        </Badge>
-                      ))}
+                  <p className="text-sm text-muted-foreground">
+                    {session.description}
+                  </p>
+                  <div className="space-y-2">
+                    <div className="flex items-center gap-2">
+                      <CalendarIcon size={16} className="text-primary" />
+                      <span className="text-sm">{session.day}</span>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <ClockIcon size={16} className="text-primary" />
+                      <div className="flex flex-wrap gap-1">
+                        {session.times.map((time, index) => (
+                          <Badge
+                            key={index}
+                            variant="outline"
+                            className="text-xs"
+                          >
+                            {time}
+                          </Badge>
+                        ))}
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <MapPinIcon size={16} className="text-primary" />
+                      <span className="text-sm">{session.location}</span>
                     </div>
                   </div>
-                  <div className="flex items-center gap-2">
-                    <MapPinIcon size={16} className="text-primary" />
-                    <span className="text-sm">{session.location}</span>
-                  </div>
-                </div>
-              </Card>
+                </Card>
+              </StaggerItem>
             ))}
-          </div>
+          </Stagger>
         </div>
       </div>
     </section>

--- a/components/HeroTemplate.tsx
+++ b/components/HeroTemplate.tsx
@@ -1,4 +1,5 @@
 import { cn } from "@/lib/utils";
+import { Reveal } from "@/components/motion";
 
 interface HeroTemplateProps {
   title?: string;
@@ -36,7 +37,10 @@ export default function HeroTemplate({
         <section>
           <div className="pb-24 pt-12">
             <div className="relative small-container flex flex-col lg:flex-center">
-              <div className="mx-auto max-w-lg text-center lg:ml-0 lg:w-1/2 lg:text-left">
+              <Reveal
+                variant="fade-up"
+                className="mx-auto max-w-lg text-center lg:ml-0 lg:w-1/2 lg:text-left"
+              >
                 <h1 className="mt-8 max-w-2xl text-balance text-5xl font-medium md:text-6xl lg:mt-16 xl:text-7xl text-shadow-md">
                   {title}
                 </h1>
@@ -49,7 +53,7 @@ export default function HeroTemplate({
                     {children}
                   </div>
                 )}
-              </div>
+              </Reveal>
             </div>
           </div>
         </section>


### PR DESCRIPTION
## Summary

- Adds fade-up reveal to the shared `HeroTemplate` component — covers the Giving and Prayer heroes (and any other page using the template)
- Animates all sections on the **Giving** page: info cards (staggered), account details card, and worldwide giving cards (staggered)
- Animates all sections on the **Prayer** page: prayer inspiration cards (staggered), prayer sessions (staggered), join prayer group (slide-in two-column), prayer points header, prayer request form (slide-in info + form card), and answered prayers header
- Prayer carousel and prayer points filter grid are intentionally left without stagger — the carousel uses transform-based positioning that conflicts with Motion, and the filter grid re-renders on tab switch which would re-trigger stagger

## Test plan
- [ ] Navigate to `/giving` — hero, info cards, account details, and worldwide cards all animate in on scroll
- [ ] Navigate to `/prayer` — hero, inspiration cards, sessions, join group form, prayer request form, and answered prayers header all animate in on scroll
- [ ] Switch filter tabs on Prayer Points — grid content should not re-animate on tab change
- [ ] Verify `prefers-reduced-motion` renders all sections statically


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smooth entrance animations to key sections across Giving and Prayer pages
  * Implemented staggered animations for content cards and grids
  * Enhanced visual experience with fade and slide transition effects throughout the app

<!-- end of auto-generated comment: release notes by coderabbit.ai -->