### PR TITLE
feat: Map directions + user-location pin, plus accessibility review fixes

### DIFF
--- a/app/(routes)/location/page.tsx
+++ b/app/(routes)/location/page.tsx
@@ -7,7 +7,7 @@ import ChurchLocationMap from "@/components/homePage/ChurchLocationMap";
 import { Reveal, Stagger, StaggerItem } from "@/components/motion";
 import { AnimatedButton } from "@/components/ui/animated-button";
 import { SERVICES, CHURCH_INFO } from "@/lib/constants";
-import { formatServiceSchedule } from "@/lib/utils";
+import { formatServiceSchedule, getDirectionsUrl } from "@/lib/utils";
 import {
   ArrowDownIcon,
   NavigationArrowIcon,
@@ -27,8 +27,7 @@ const { address, coordinates, parking, description, directions, accessibility } 
 const { lat, lng } = coordinates;
 
 const FULL_ADDRESS = `${address.street}, ${address.city}, ${address.region}, ${address.country}`;
-// Turn-by-turn directions — opens the device's map app on mobile.
-const DIRECTIONS_URL = `https://www.google.com/maps/dir/?api=1&destination=${lat},${lng}`;
+const DIRECTIONS_URL = getDirectionsUrl(lat, lng);
 
 export default function LocationPage() {
   return (

--- a/app/(routes)/location/page.tsx
+++ b/app/(routes)/location/page.tsx
@@ -27,7 +27,8 @@ const { address, coordinates, parking, description, directions, accessibility } 
 const { lat, lng } = coordinates;
 
 const FULL_ADDRESS = `${address.street}, ${address.city}, ${address.region}, ${address.country}`;
-const DIRECTIONS_URL = `https://www.google.com/maps/search/?api=1&query=${lat},${lng}`;
+// Turn-by-turn directions — opens the device's map app on mobile.
+const DIRECTIONS_URL = `https://www.google.com/maps/dir/?api=1&destination=${lat},${lng}`;
 
 export default function LocationPage() {
   return (

--- a/app/(routes)/prayer/PrayerPoints.tsx
+++ b/app/(routes)/prayer/PrayerPoints.tsx
@@ -182,9 +182,9 @@ export default function PrayerPoints({ initialCategory }: PrayerPointsProps) {
                     <div className="space-y-6">
                       {/* Intercessions */}
                       <div>
-                        <h5 className="text-sm font-semibold mb-3 text-primary">
+                        <h4 className="text-sm font-semibold mb-3 text-primary">
                           Intercessions
-                        </h5>
+                        </h4>
                         <div className="space-y-4">
                           {point.intercessions.map((intercession, index) => (
                             <div key={index} className="space-y-2 border-b ">
@@ -215,9 +215,9 @@ export default function PrayerPoints({ initialCategory }: PrayerPointsProps) {
                       {/* Personal Thanksgiving */}
                       {point.personalThanksgiving && (
                         <div>
-                          <h5 className="text-sm font-semibold mb-3 text-primary">
+                          <h4 className="text-sm font-semibold mb-3 text-primary">
                             Personal Thanksgiving
-                          </h5>
+                          </h4>
                           <div className="space-y-2">
                             <p className="text-sm leading-relaxed">
                               {point.personalThanksgiving.prayer}

--- a/app/(routes)/prayer/PrayerRequestForm.tsx
+++ b/app/(routes)/prayer/PrayerRequestForm.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/components/ui/field";
 import { PaperPlaneTiltIcon } from "@phosphor-icons/react";
 import { CHURCH_INFO, PRAYER_CATEGORIES } from "@/lib/constants";
+import { getDirectionsUrl } from "@/lib/utils";
 import { Reveal } from "@/components/motion";
 
 type PrayerRequestFormValues = {
@@ -83,8 +84,7 @@ export default function PrayerRequestForm() {
     address: churchAddress = "",
   } = CONTACT;
   const { lat, lng } = CHURCH_INFO.CHURCH_LOCATION.coordinates;
-  // Opens turn-by-turn directions — launches the device's map app on mobile.
-  const directionsUrl = `https://www.google.com/maps/dir/?api=1&destination=${lat},${lng}`;
+  const directionsUrl = getDirectionsUrl(lat, lng);
 
   const form = useForm<PrayerRequestFormValues>({
     resolver: yupResolver(prayerRequestSchema),

--- a/app/(routes)/prayer/PrayerRequestForm.tsx
+++ b/app/(routes)/prayer/PrayerRequestForm.tsx
@@ -82,6 +82,9 @@ export default function PrayerRequestForm() {
     email: churchEmail = "",
     address: churchAddress = "",
   } = CONTACT;
+  const { lat, lng } = CHURCH_INFO.CHURCH_LOCATION.coordinates;
+  // Opens turn-by-turn directions — launches the device's map app on mobile.
+  const directionsUrl = `https://www.google.com/maps/dir/?api=1&destination=${lat},${lng}`;
 
   const form = useForm<PrayerRequestFormValues>({
     resolver: yupResolver(prayerRequestSchema),
@@ -249,10 +252,15 @@ export default function PrayerRequestForm() {
             </div>
             <div>
               <h2 className="mb-3 text-lg">Church Premises</h2>
-              {/* NOTE: Fix to open directions in Google Maps */}
-              <p className="text-red-700 dark:text-primary text-lg hover:underline">
+              <a
+                href={directionsUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={`Get directions to ${churchAddress}`}
+                className="text-red-700 dark:text-primary text-lg hover:underline"
+              >
                 {churchAddress}
-              </p>
+              </a>
               <p className="mt-3 text-sm">
                 You can submit your prayer request to the ushers during any of
                 our services.

--- a/app/(routes)/testimonies/ShareTestimonyForm.tsx
+++ b/app/(routes)/testimonies/ShareTestimonyForm.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/components/ui/field";
 import { PaperPlaneTiltIcon } from "@phosphor-icons/react";
 import { CHURCH_INFO, TESTIMONY_CATEGORIES } from "@/lib/constants";
+import { getDirectionsUrl } from "@/lib/utils";
 
 type TestimonyFormValues = {
   name?: string;
@@ -134,8 +135,7 @@ export default function ShareTestimonyForm() {
     address: churchAddress = "",
   } = CONTACT;
   const { lat, lng } = CHURCH_INFO.CHURCH_LOCATION.coordinates;
-  // Opens turn-by-turn directions — launches the device's map app on mobile.
-  const directionsUrl = `https://www.google.com/maps/dir/?api=1&destination=${lat},${lng}`;
+  const directionsUrl = getDirectionsUrl(lat, lng);
 
   const form = useForm<TestimonyFormValues>({
     resolver: yupResolver(testimonySchema),

--- a/app/(routes)/testimonies/ShareTestimonyForm.tsx
+++ b/app/(routes)/testimonies/ShareTestimonyForm.tsx
@@ -133,6 +133,9 @@ export default function ShareTestimonyForm() {
     email: churchEmail = "",
     address: churchAddress = "",
   } = CONTACT;
+  const { lat, lng } = CHURCH_INFO.CHURCH_LOCATION.coordinates;
+  // Opens turn-by-turn directions — launches the device's map app on mobile.
+  const directionsUrl = `https://www.google.com/maps/dir/?api=1&destination=${lat},${lng}`;
 
   const form = useForm<TestimonyFormValues>({
     resolver: yupResolver(testimonySchema),
@@ -462,10 +465,15 @@ export default function ShareTestimonyForm() {
             </div>
             <div>
               <h2 className="mb-3 text-lg">Church Premises</h2>
-              {/* NOTE: Fix to open directions in Google Maps */}
-              <p className="text-red-700 dark:text-primary text-lg hover:underline">
+              <a
+                href={directionsUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={`Get directions to ${churchAddress}`}
+                className="text-red-700 dark:text-primary text-lg hover:underline"
+              >
                 {churchAddress}
-              </p>
+              </a>
               <p className="mt-3 text-sm">
                 You can submit your testimony to the ushers during any of our
                 services.

--- a/components/homePage/ChurchLocationMap.tsx
+++ b/components/homePage/ChurchLocationMap.tsx
@@ -12,6 +12,7 @@ import {
   SignpostIcon,
 } from "@phosphor-icons/react";
 import { CHURCH_INFO } from "@/lib/constants";
+import { getDirectionsUrl } from "@/lib/utils";
 import "leaflet/dist/leaflet.css";
 
 const { NAME } = CHURCH_INFO;
@@ -19,8 +20,7 @@ const { address, coordinates } = CHURCH_INFO.CHURCH_LOCATION ?? {};
 const { city = "", country = "" } = address ?? {};
 const { lat, lng } = coordinates ?? {};
 
-// Turn-by-turn directions — opens the device's map app on mobile.
-const DIRECTIONS_URL = `https://www.google.com/maps/dir/?api=1&destination=${lat},${lng}`;
+const DIRECTIONS_URL = getDirectionsUrl(lat, lng);
 
 const MARKER_HTML = `
   <div style="

--- a/components/homePage/ChurchLocationMap.tsx
+++ b/components/homePage/ChurchLocationMap.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import type { Map as LeafletMap } from "leaflet";
+import type { Map as LeafletMap, Marker as LeafletMarker } from "leaflet";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { AnimatedButton } from "@/components/ui/animated-button";
@@ -9,6 +9,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import {
   ArrowCounterClockwiseIcon,
   NavigationArrowIcon,
+  SignpostIcon,
 } from "@phosphor-icons/react";
 import { CHURCH_INFO } from "@/lib/constants";
 import "leaflet/dist/leaflet.css";
@@ -18,11 +19,12 @@ const { address, coordinates } = CHURCH_INFO.CHURCH_LOCATION ?? {};
 const { city = "", country = "" } = address ?? {};
 const { lat, lng } = coordinates ?? {};
 
-const DIRECTIONS_URL = `https://www.google.com/maps/search/?api=1&query=${lat},${lng}`;
+// Turn-by-turn directions — opens the device's map app on mobile.
+const DIRECTIONS_URL = `https://www.google.com/maps/dir/?api=1&destination=${lat},${lng}`;
 
 const MARKER_HTML = `
   <div style="
-    background:#ef4444;width:40px;height:40px;border-radius:50% 50% 50% 0;
+    background:#dc2626;width:40px;height:40px;border-radius:50% 50% 50% 0;
     transform:rotate(-45deg);border:3px solid white;
     box-shadow:0 2px 8px rgba(0,0,0,0.3);display:flex;align-items:center;justify-content:center;
   ">
@@ -30,12 +32,32 @@ const MARKER_HTML = `
   </div>
 `;
 
+// Distinct blue dot for the visitor's own position (vs the red church pin).
+const USER_MARKER_HTML = `
+  <div style="
+    width:18px;height:18px;border-radius:50%;background:#2563eb;border:3px solid white;
+    box-shadow:0 0 0 4px rgba(37,99,235,0.25),0 2px 6px rgba(0,0,0,0.3);
+  "></div>
+`;
+
+const USER_POPUP_HTML = `
+  <div style="display:flex;align-items:center;gap:7px;padding:7px 11px;white-space:nowrap;font-weight:600;font-size:0.85rem;color:#1e293b">
+    <span style="width:9px;height:9px;border-radius:50%;background:#2563eb;flex:none"></span>
+    You are here
+  </div>
+`;
+
 const POPUP_HTML = `
-  <div style="min-width:190px;padding:2px">
-    <h3 style="font-weight:700;font-size:1.05rem;line-height:1.2;margin:0 0 4px">${NAME}</h3>
-    <p style="font-size:0.7rem;text-transform:uppercase;letter-spacing:0.05em;color:#64748b;margin:0 0 12px">${city}, ${country}</p>
+  <div style="min-width:208px">
+    <div style="padding:13px 16px 12px">
+      <h3 style="font-weight:700;font-size:0.95rem;line-height:1.25;margin:0 0 5px;color:#0f172a">${NAME}</h3>
+      <p style="display:inline-flex;align-items:center;gap:6px;font-size:0.68rem;text-transform:uppercase;letter-spacing:0.07em;color:#64748b;margin:0">
+        <span style="width:6px;height:6px;border-radius:50%;background:#dc2626;flex:none"></span>
+        ${city}, ${country}
+      </p>
+    </div>
     <a href="${DIRECTIONS_URL}" target="_blank" rel="noopener noreferrer"
-      style="display:flex;align-items:center;justify-content:center;gap:6px;background:#ef4444;color:#fff;font-weight:600;font-size:0.85rem;padding:8px 12px;border-radius:8px;text-decoration:none">
+      style="display:flex;align-items:center;justify-content:center;gap:7px;background:#dc2626;color:#fff;font-weight:600;font-size:0.85rem;padding:11px 12px;text-decoration:none">
       Get Directions &rarr;
     </a>
   </div>
@@ -52,6 +74,8 @@ const POPUP_HTML = `
 export default function ChurchLocationMap() {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const mapRef = useRef<LeafletMap | null>(null);
+  const leafletRef = useRef<typeof import("leaflet") | null>(null);
+  const userMarkerRef = useRef<LeafletMarker | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -61,6 +85,8 @@ export default function ChurchLocationMap() {
       // already exists for this instance.
       if (cancelled || !containerRef.current || mapRef.current) return;
       if (lat === undefined || lng === undefined) return;
+
+      leafletRef.current = L;
 
       const map = L.map(containerRef.current, {
         center: [lat, lng],
@@ -82,7 +108,9 @@ export default function ChurchLocationMap() {
         popupAnchor: [0, -40],
       });
 
-      L.marker([lat, lng], { icon }).addTo(map).bindPopup(POPUP_HTML);
+      L.marker([lat, lng], { icon })
+        .addTo(map)
+        .bindPopup(POPUP_HTML, { closeButton: false });
     });
 
     // Destroy the map on unmount so its container is released cleanly.
@@ -92,10 +120,17 @@ export default function ChurchLocationMap() {
         mapRef.current.remove();
         mapRef.current = null;
       }
+      leafletRef.current = null;
+      userMarkerRef.current = null;
     };
   }, []);
 
   const handleReset = () => {
+    // Drop the visitor's pin and re-center on the church.
+    if (userMarkerRef.current) {
+      userMarkerRef.current.remove();
+      userMarkerRef.current = null;
+    }
     if (lat !== undefined && lng !== undefined) {
       mapRef.current?.setView([lat, lng], 15);
     }
@@ -109,13 +144,46 @@ export default function ChurchLocationMap() {
 
     navigator.geolocation.getCurrentPosition(
       (pos) => {
-        mapRef.current?.setView(
-          [pos.coords.latitude, pos.coords.longitude],
-          15
-        );
+        const L = leafletRef.current;
+        const map = mapRef.current;
+        if (!L || !map) return;
+
+        const userLatLng: [number, number] = [
+          pos.coords.latitude,
+          pos.coords.longitude,
+        ];
+
+        // Reuse the existing pin on repeat clicks instead of stacking markers.
+        if (userMarkerRef.current) {
+          userMarkerRef.current.setLatLng(userLatLng);
+        } else {
+          const userIcon = L.divIcon({
+            html: USER_MARKER_HTML,
+            className: "custom-marker",
+            iconSize: [24, 24],
+            iconAnchor: [12, 12],
+            popupAnchor: [0, -12],
+          });
+          userMarkerRef.current = L.marker(userLatLng, { icon: userIcon })
+            .addTo(map)
+            .bindPopup(USER_POPUP_HTML, { closeButton: false });
+        }
+
+        // Frame both the church and the visitor so the relationship is clear.
+        if (lat !== undefined && lng !== undefined) {
+          map.fitBounds([[lat, lng], userLatLng], {
+            padding: [60, 60],
+            maxZoom: 15,
+          });
+        } else {
+          map.setView(userLatLng, 15);
+        }
+        userMarkerRef.current.openPopup();
       },
       (err) => {
-        console.error(err);
+        if (process.env.NODE_ENV === "development") {
+          console.error(err);
+        }
         toast.error("Unable to get your location");
       },
       { enableHighAccuracy: true, timeout: 8000 }
@@ -129,13 +197,22 @@ export default function ChurchLocationMap() {
           <div ref={containerRef} className="z-0 h-full w-full" />
 
           {/* CONTROL: Bottom Center */}
-          <div className="absolute bottom-6 left-1/2 -translate-x-1/2 z-1000 flex gap-4 w-max max-w-[90%]">
+          <div className="absolute bottom-6 left-1/2 -translate-x-1/2 z-1000 flex flex-wrap justify-center gap-3 w-max max-w-[90%]">
             <AnimatedButton
               size="sm"
               variant="default"
+              href={DIRECTIONS_URL}
+              text="Get Directions"
+              icon={<SignpostIcon weight="fill" />}
+              className="rounded-full shadow-lg bg-primary/90 hover:bg-primary backdrop-blur-sm shrink-0"
+            />
+
+            <AnimatedButton
+              size="sm"
+              variant="outline"
               text="View My Location"
               icon={<NavigationArrowIcon weight="fill" />}
-              className="rounded-full shadow-lg bg-primary/90 hover:bg-primary backdrop-blur-sm shrink-0"
+              className="rounded-full shadow-lg bg-white/90 hover:bg-white text-primary hover:text-primary backdrop-blur-sm shrink-0"
               onClick={handleViewMyLocation}
             />
 

--- a/lib/constants/site.ts
+++ b/lib/constants/site.ts
@@ -8,10 +8,26 @@ import { CHURCH_INFO } from "./church";
  * a single source of truth. Update values here and they propagate everywhere.
  */
 
-/** Production base URL — override with NEXT_PUBLIC_SITE_URL in the environment. */
-export const SITE_URL = (
-  process.env.NEXT_PUBLIC_SITE_URL ?? "https://wcigoderich.org"
-).replace(/\/$/, "");
+const DEFAULT_SITE_URL = "https://wcigoderich.org";
+
+/**
+ * Production base URL — override with NEXT_PUBLIC_SITE_URL in the environment.
+ * Validated to be an absolute http(s) URL so downstream `new URL(SITE_URL)`
+ * calls (e.g. metadataBase) can't throw on a malformed env value.
+ */
+function resolveSiteUrl(): string {
+  const raw = process.env.NEXT_PUBLIC_SITE_URL?.trim();
+  if (!raw) return DEFAULT_SITE_URL;
+  try {
+    const { protocol } = new URL(raw);
+    if (protocol !== "https:" && protocol !== "http:") return DEFAULT_SITE_URL;
+    return raw.replace(/\/$/, "");
+  } catch {
+    return DEFAULT_SITE_URL;
+  }
+}
+
+export const SITE_URL = resolveSiteUrl();
 
 /** The developer of this site (author attribution). */
 export const AUTHOR = {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -95,6 +95,17 @@ export function isValidUrl(url: string): boolean {
 }
 
 /**
+ * Builds a Google Maps turn-by-turn directions URL to the given coordinates.
+ * Opens the device's native map app on mobile.
+ * @param lat - Destination latitude
+ * @param lng - Destination longitude
+ * @returns Google Maps directions URL
+ */
+export function getDirectionsUrl(lat: number, lng: number): string {
+  return `https://www.google.com/maps/dir/?api=1&destination=${lat},${lng}`;
+}
+
+/**
  * Formats a number as an ordinal (1st, 2nd, 3rd, 4th, etc.)
  * @param n - Number to format
  * @returns Formatted ordinal string


### PR DESCRIPTION
Builds on the SEO/a11y/performance pass (#48) with a couple of follow-ups.

## Location map
- Add a **Get Directions** button to the map control bar — opens turn-by-turn directions (launches the device's native map app on mobile). Switched every directions link (map popup, control bar, location hero + CTA) from a `search` query to the `dir/` endpoint so they actually route.
- **View My Location** now drops a distinct blue **"You are here"** pin, fits both the church and visitor pins in view, reuses the pin on repeat clicks, and clears it on **Reset View**.
- Restyled both map popups: full-width title, brand-red accent, full-width button footer, and removed the oversized overlapping close button. Aligned the church marker to the brand red (`#dc2626`).

## Accessibility review fixes
- Promote the "Intercessions" / "Personal Thanksgiving" labels from `h5` → `h4` so the prayer-point card heading order (`h3` → `h4`) no longer skips a level.
- Render the church address as a real anchor to Google Maps directions (prayer + testimonies forms) instead of a `<p>` styled like a link — now keyboard- and screen-reader-accessible.
- Validate `NEXT_PUBLIC_SITE_URL` as an absolute `http(s)` URL with a fallback, so `new URL(SITE_URL)` can't throw on a malformed env value.

## Validation
`tsc --noEmit` and `pnpm build` pass; spot-checked the directions links, the user pin, and both popups on a production build.
